### PR TITLE
adds flexible image to terraform example

### DIFF
--- a/terraform/service-templates/ecs-fargate-load-balanced-service/instance_infrastructure/src/main.tf
+++ b/terraform/service-templates/ecs-fargate-load-balanced-service/instance_infrastructure/src/main.tf
@@ -140,6 +140,16 @@ resource "aws_ecs_task_definition" "main" {
           "protocol": "tcp"
         }
       ],
+      "environment": [
+        {
+          "name": "PORT",
+          "value": "${var.container_port}"
+        },
+        {
+          "name": "HEALTHCHECK",
+          "value": "${var.health_check_path}"
+        }
+      ]
       "logConfiguration": {
         "logDriver": "awslogs",
         "options": {

--- a/terraform/service-templates/ecs-fargate-load-balanced-service/schema/schema.yaml
+++ b/terraform/service-templates/ecs-fargate-load-balanced-service/schema/schema.yaml
@@ -11,14 +11,14 @@ schema:
           type: number
           title: "Container Port"
           description: "The port the container listens on"
-          default: 80
+          default: 8080
           minimum: 0
           maximum: 65535
         health_check_path:
           title: Health Check Path
           description: The health check path
           type: string
-          default: /
+          default: /health
         desired_count:
           type: number
           title: "Desired Task Count"
@@ -40,7 +40,7 @@ schema:
         image:
           type: string
           title: "Container Image"
-          description: "The name/url of the container image"
-          default: "public.ecr.aws/z9d2n7e1/nginx:1.21.1"
+          description: "The container image to deploy"
+          default: "public.ecr.aws/aws-containers/proton-demo-image:1e5ca1d"
           minLength: 1
           maxLength: 200


### PR DESCRIPTION
Rather than deploying nginx as the default image with a fixed port and health check path, this deploys a small custom lightweight image that can be configured to listen on a particular port and health check path via envvars.  This allows Proton customers to set the `port` and `health_check_path` template input parameters to whatever their app uses and get a clean healthy initial deployment.  They can then later update the service to deploy their custom image.