### PR TITLE
fixes for cdk example minifest

### DIFF
--- a/cdk/manifest.yaml
+++ b/cdk/manifest.yaml
@@ -9,7 +9,7 @@ infrastructure:
           # Run when create/update is triggered for environment or service
           # Install dependencies
           - npm install
-          - cdk deploy --require-approval never
+          - npm run cdk deploy --require-approval never
           # Script to convert CFN outputs into outputs for Proton
           - chmod +x ./cdk-to-proton.sh
           - cat proton-outputs.json | ./cdk-to-proton.sh > outputs.json
@@ -18,4 +18,4 @@ infrastructure:
         deprovision:
           # Install dependencies and destroy resources
           - npm install
-          - cdk destroy --force
+          - npm run cdk destroy --force


### PR DESCRIPTION
codebuild gives the following error.

After writing the same description as the document, the error was resolved.
[Example: using the AWS CDK with CodeBuild provisioning
](https://docs.aws.amazon.com/proton/latest/userguide/ag-infrastructure-tmp-files-codebuild.html)

```
$ cdk destroy --force
/codebuild/output/tmp/script.sh: line 4: cdk: command not found
67
```