### PR TITLE
Remove status flag from CodeBuild templates as it's not needed anymore

### DIFF
--- a/cdk/README.md
+++ b/cdk/README.md
@@ -29,7 +29,7 @@ Prior to launching CDK Stacks, a [bootstrap](https://docs.aws.amazon.com/cdk/v2/
   - Proton needs to be notified when the deployment is complete. If the Codebuild job fails, Proton will surface that information. On success, the following command needs to be ran:
 
   ```bash
-  aws proton notify-resource-deployment-status-change --resource-arn $RESOURCE_ARN --status IN_PROGRESS --outputs file://./outputs.json
+  aws proton notify-resource-deployment-status-change --resource-arn $RESOURCE_ARN --outputs file://./outputs.json
   ```
 
 ### Examples

--- a/cdk/environment-templates/cdk-vpc-ecs-cluster/v1/infrastructure/manifest.yaml
+++ b/cdk/environment-templates/cdk-vpc-ecs-cluster/v1/infrastructure/manifest.yaml
@@ -14,7 +14,7 @@ infrastructure:
           - chmod +x ./cdk-to-proton.sh
           - cat proton-outputs.json | ./cdk-to-proton.sh > outputs.json
           # Notify AWS Proton of deployment status
-          - aws proton notify-resource-deployment-status-change --resource-arn $RESOURCE_ARN --status SUCCEEDED --outputs file://./outputs.json
+          - aws proton notify-resource-deployment-status-change --resource-arn $RESOURCE_ARN --outputs file://./outputs.json
         deprovision:
           # Install dependencies and destroy resources
           - npm install

--- a/cdk/environment-templates/cdk-vpc-eks-cluster/v1/infrastructure/manifest.yaml
+++ b/cdk/environment-templates/cdk-vpc-eks-cluster/v1/infrastructure/manifest.yaml
@@ -11,7 +11,7 @@ infrastructure:
           - chmod +x ./cdk_deploy.sh ./cdk-to-proton.sh
           - ./cdk_deploy.sh
           - cat proton-outputs.json | ./cdk-to-proton.sh > outputs.json
-          - aws proton notify-resource-deployment-status-change --resource-arn $RESOURCE_ARN --status SUCCEEDED --outputs file://./outputs.json
+          - aws proton notify-resource-deployment-status-change --resource-arn $RESOURCE_ARN --outputs file://./outputs.json
         deprovision:
           - npm install
           - echo "{}" | tee  ./pre-req-outputs.json

--- a/cdk/manifest.yaml
+++ b/cdk/manifest.yaml
@@ -14,7 +14,7 @@ infrastructure:
           - chmod +x ./cdk-to-proton.sh
           - cat proton-outputs.json | ./cdk-to-proton.sh > outputs.json
           # Notify AWS Proton of deployment status
-          - aws proton notify-resource-deployment-status-change --resource-arn $RESOURCE_ARN --status IN_PROGRESS --outputs file://./outputs.json
+          - aws proton notify-resource-deployment-status-change --resource-arn $RESOURCE_ARN --outputs file://./outputs.json
         deprovision:
           # Install dependencies and destroy resources
           - npm install

--- a/cdk/service-templates/cdk-ecs-fargate-service/v1/instance_infrastructure/manifest.yaml
+++ b/cdk/service-templates/cdk-ecs-fargate-service/v1/instance_infrastructure/manifest.yaml
@@ -14,7 +14,7 @@ infrastructure:
           - chmod +x ./cdk-to-proton.sh
           - cat proton-outputs.json | ./cdk-to-proton.sh > outputs.json
           # Notify AWS Proton of deployment status
-          - aws proton notify-resource-deployment-status-change --resource-arn $RESOURCE_ARN --status SUCCEEDED --outputs file://./outputs.json
+          - aws proton notify-resource-deployment-status-change --resource-arn $RESOURCE_ARN --outputs file://./outputs.json
         deprovision:
           # Install dependencies and destroy resources
           - npm install

--- a/pulumi/README.md
+++ b/pulumi/README.md
@@ -32,7 +32,7 @@ Codebuild will reference this secret which is defined in the manifest file. More
   - Proton needs to be notified when the deployment is complete. If the Codebuild job fails, Proton will surface that information. On success, the following command needs to be ran:
 
   ```bash
-  aws proton notify-resource-deployment-status-change --resource-arn $RESOURCE_ARN --status IN_PROGRESS --outputs file://./outputs.json
+  aws proton notify-resource-deployment-status-change --resource-arn $RESOURCE_ARN --outputs file://./outputs.json
   ```
 
 ### Examples

--- a/pulumi/environment-templates/vpc-ecs-cluster/v1/infrastructure/manifest.yaml
+++ b/pulumi/environment-templates/vpc-ecs-cluster/v1/infrastructure/manifest.yaml
@@ -28,7 +28,7 @@ infrastructure:
           # Running script to convert pulumi outputs for Proton to injest and update Proton on deployment status
           - chmod +x ./pulumi-to-proton-outputs.sh
           - pulumi stack output --json | ./pulumi-to-proton-outputs.sh > outputs.json
-          - aws proton notify-resource-deployment-status-change --resource-arn $RESOURCE_ARN --status IN_PROGRESS --outputs file://./outputs.json
+          - aws proton notify-resource-deployment-status-change --resource-arn $RESOURCE_ARN --outputs file://./outputs.json
         deprovision:
           # Steps to be ran when an environment is deleted
           # Download Pulumi binary and install dependencies

--- a/pulumi/manifest.yaml
+++ b/pulumi/manifest.yaml
@@ -28,7 +28,7 @@ infrastructure:
           # Running script to convert pulumi outputs for Proton to injest and update Proton on deployment status
           - chmod +x ./pulumi-to-proton-outputs.sh
           - pulumi stack output --json | ./pulumi-to-proton-outputs.sh > outputs.json
-          - aws proton notify-resource-deployment-status-change --resource-arn $RESOURCE_ARN --status IN_PROGRESS --outputs file://./outputs.json
+          - aws proton notify-resource-deployment-status-change --resource-arn $RESOURCE_ARN --outputs file://./outputs.json
         deprovision:
           # Steps to be ran when an environment is deleted
           # Download Pulumi binary and install dependencies

--- a/pulumi/service-templates/ecs-fargate-load-balanced-service/v1/instance_infrastructure/manifest.yaml
+++ b/pulumi/service-templates/ecs-fargate-load-balanced-service/v1/instance_infrastructure/manifest.yaml
@@ -28,7 +28,7 @@ infrastructure:
           # Running script to convert pulumi outputs for Proton to injest and update Proton on deployment status
           - chmod +x ./pulumi-to-proton-outputs.sh
           - pulumi stack output --json | ./pulumi-to-proton-outputs.sh > outputs.json
-          - aws proton notify-resource-deployment-status-change --resource-arn $RESOURCE_ARN --status IN_PROGRESS --outputs file://./outputs.json
+          - aws proton notify-resource-deployment-status-change --resource-arn $RESOURCE_ARN --outputs file://./outputs.json
         deprovision:
           # Steps to be ran when a service is deleted
           # Download Pulumi binary and install dependencies

--- a/terraform/environment-templates/tf-vpc-ecs-cluster/v1/infrastructure/output.sh
+++ b/terraform/environment-templates/tf-vpc-ecs-cluster/v1/infrastructure/output.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -e
 terraform output -json | jq 'to_entries | map({key:.key, valueString:.value.value})' > output.json
-aws proton notify-resource-deployment-status-change --resource-arn ${RESOURCE_ARN} --status IN_PROGRESS --outputs file://./output.json
+aws proton notify-resource-deployment-status-change --resource-arn ${RESOURCE_ARN} --outputs file://./output.json

--- a/terraform/service-templates/tf-ecs-fargate-lb-service-cicd-codepipeline/v1/instance_infrastructure/output.sh
+++ b/terraform/service-templates/tf-ecs-fargate-lb-service-cicd-codepipeline/v1/instance_infrastructure/output.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -e
 terraform output -json | jq 'to_entries | map({key:.key, valueString:.value.value})' > output.json
-aws proton notify-resource-deployment-status-change --resource-arn ${RESOURCE_ARN} --status IN_PROGRESS --outputs file://./output.json
+aws proton notify-resource-deployment-status-change --resource-arn ${RESOURCE_ARN} --outputs file://./output.json

--- a/terraform/service-templates/tf-ecs-fargate-lb-service-cicd-codepipeline/v1/pipeline_infrastructure/output.sh
+++ b/terraform/service-templates/tf-ecs-fargate-lb-service-cicd-codepipeline/v1/pipeline_infrastructure/output.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -e
 terraform output -json | jq 'to_entries | map({key:.key, valueString:.value.value})' > output.json
-aws proton notify-resource-deployment-status-change --resource-arn ${RESOURCE_ARN} --status IN_PROGRESS --outputs file://./output.json
+aws proton notify-resource-deployment-status-change --resource-arn ${RESOURCE_ARN} --outputs file://./output.json

--- a/terraform/service-templates/tf-ecs-fargate-lb-service/v1/instance_infrastructure/output.sh
+++ b/terraform/service-templates/tf-ecs-fargate-lb-service/v1/instance_infrastructure/output.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -e
 terraform output -json | jq 'to_entries | map({key:.key, valueString:.value.value})' > output.json
-aws proton notify-resource-deployment-status-change --resource-arn ${RESOURCE_ARN} --status IN_PROGRESS --outputs file://./output.json
+aws proton notify-resource-deployment-status-change --resource-arn ${RESOURCE_ARN} --outputs file://./output.json


### PR DESCRIPTION
A latest service code change made it optional to provide the `--status` flag for codebuild provisioning. This code change removes that flag from our template samples as it's not needed anymore.