### PR TITLE
terraform - fixes first time oidc provider creation

### DIFF
--- a/terraform/service-templates/tf-ecs-fargate-lb-service-cicd-gh-actions/v1/pipeline_infrastructure/scripts/oidc.sh
+++ b/terraform/service-templates/tf-ecs-fargate-lb-service-cicd-gh-actions/v1/pipeline_infrastructure/scripts/oidc.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
 
-cd ../oidc-identity-provider
+cd ./oidc-identity-provider
 terraform init
 terraform apply -auto-approve


### PR DESCRIPTION
applies to the [tf-ecs-fargate-lb-service-cicd-gh-actions](https://github.com/aws-containers/proton-codebuild-provisioning-examples/tree/main/terraform/service-templates/tf-ecs-fargate-lb-service-cicd-gh-actions/v1) template