### PR TITLE
adds `docker_path` to tf cicd-gh-actions template

### DIFF
--- a/terraform/service-templates/tf-ecs-fargate-lb-service-cicd-gh-actions/v1/pipeline_infrastructure/README.md
+++ b/terraform/service-templates/tf-ecs-fargate-lb-service-cicd-gh-actions/v1/pipeline_infrastructure/README.md
@@ -26,6 +26,7 @@ No resources.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_pipeline"></a> [pipeline](#input\_pipeline) | the proton pipeline | <pre>object({<br>    inputs = any<br>  })</pre> | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | aws region | `string` | `"us-east-1"` | no |
 | <a name="input_service"></a> [service](#input\_service) | proton service | <pre>object({<br>    name                      = string<br>    repository_id             = string<br>    repository_connection_arn = string<br>    branch_name               = string<br>  })</pre> | n/a | yes |
 | <a name="input_service_instances"></a> [service\_instances](#input\_service\_instances) | the service instances | <pre>list(<br>    object({<br>      name    = string<br>      inputs  = any<br>      outputs = any<br>      environment = object({<br>        account_id = string<br>        name       = string<br>        outputs    = any<br>      })<br>    })<br>  )</pre> | `null` | no |

--- a/terraform/service-templates/tf-ecs-fargate-lb-service-cicd-gh-actions/v1/pipeline_infrastructure/main.tf
+++ b/terraform/service-templates/tf-ecs-fargate-lb-service-cicd-gh-actions/v1/pipeline_infrastructure/main.tf
@@ -28,4 +28,5 @@ module "cicd_pipeline" {
   proton_service_instances = var.service_instances
   repository_id            = var.service.repository_id
   branch_name              = var.service.branch_name
+  docker_path              = var.pipeline.inputs.docker_path
 }

--- a/terraform/service-templates/tf-ecs-fargate-lb-service-cicd-gh-actions/v1/pipeline_infrastructure/src/README.md
+++ b/terraform/service-templates/tf-ecs-fargate-lb-service-cicd-gh-actions/v1/pipeline_infrastructure/src/README.md
@@ -33,6 +33,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_branch_name"></a> [branch\_name](#input\_branch\_name) | the repo branch to deploy | `string` | n/a | yes |
+| <a name="input_docker_path"></a> [docker\_path](#input\_docker\_path) | Docker build context is the set of files located in the specified PATH | `string` | n/a | yes |
 | <a name="input_proton_service"></a> [proton\_service](#input\_proton\_service) | the name of the proton service | `string` | n/a | yes |
 | <a name="input_proton_service_instances"></a> [proton\_service\_instances](#input\_proton\_service\_instances) | the service instances | <pre>list(<br>    object({<br>      name    = string<br>      inputs  = any<br>      outputs = any<br>      environment = object({<br>        account_id = string<br>        name       = string<br>        outputs    = any<br>      })<br>    })<br>  )</pre> | `null` | no |
 | <a name="input_repository_id"></a> [repository\_id](#input\_repository\_id) | the proton pipeline connected git repo | `string` | n/a | yes |

--- a/terraform/service-templates/tf-ecs-fargate-lb-service-cicd-gh-actions/v1/pipeline_infrastructure/src/deploy-template.yml
+++ b/terraform/service-templates/tf-ecs-fargate-lb-service-cicd-gh-actions/v1/pipeline_infrastructure/src/deploy-template.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
 
-   - name: Assume AWS IAM Role
+    - name: Assume AWS IAM Role
       uses: aws-actions/configure-aws-credentials@v1-node16
       with:
         aws-region: ${region}
@@ -42,7 +42,7 @@ jobs:
         ECR_REGISTRY: $${{ steps.login-ecr.outputs.registry }}
         IMAGE_TAG: $${{ github.sha }}
       run: |
-        docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+        docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG ${docker_path}
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
         echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
 
@@ -68,4 +68,3 @@ jobs:
           --name ${instance.name}
 
 %{ endfor ~}
-

--- a/terraform/service-templates/tf-ecs-fargate-lb-service-cicd-gh-actions/v1/pipeline_infrastructure/src/main.tf
+++ b/terraform/service-templates/tf-ecs-fargate-lb-service-cicd-gh-actions/v1/pipeline_infrastructure/src/main.tf
@@ -85,7 +85,8 @@ resource "local_file" "workflow" {
     role                     = aws_iam_role.github_actions.arn,
     ecr_repo                 = aws_ecr_repository.main.name,
     branch_name              = var.branch_name,
-    proton_service           = var.proton_service
-    proton_service_instances = var.proton_service_instances
+    proton_service           = var.proton_service,
+    proton_service_instances = var.proton_service_instances,
+    docker_path              = var.docker_path,
   })
 }

--- a/terraform/service-templates/tf-ecs-fargate-lb-service-cicd-gh-actions/v1/pipeline_infrastructure/src/variables.tf
+++ b/terraform/service-templates/tf-ecs-fargate-lb-service-cicd-gh-actions/v1/pipeline_infrastructure/src/variables.tf
@@ -29,3 +29,8 @@ variable "branch_name" {
   description = "the repo branch to deploy"
   type        = string
 }
+
+variable "docker_path" {
+  description = "Docker build context is the set of files located in the specified PATH"
+  type        = string
+}

--- a/terraform/service-templates/tf-ecs-fargate-lb-service-cicd-gh-actions/v1/pipeline_infrastructure/variables.tf
+++ b/terraform/service-templates/tf-ecs-fargate-lb-service-cicd-gh-actions/v1/pipeline_infrastructure/variables.tf
@@ -1,11 +1,11 @@
 # required by proton
 
-# variable "pipeline" {
-#   description = "the proton pipeline"
-#   type = object({
-#     inputs = any
-#   })
-# }
+variable "pipeline" {
+  description = "the proton pipeline"
+  type = object({
+    inputs = any
+  })
+}
 
 variable "service" {
   description = "proton service"

--- a/terraform/service-templates/tf-ecs-fargate-lb-service-cicd-gh-actions/v1/schema/schema.yaml
+++ b/terraform/service-templates/tf-ecs-fargate-lb-service-cicd-gh-actions/v1/schema/schema.yaml
@@ -55,3 +55,10 @@ schema:
           type: string
           title: GitHub PAT Secret Name
           description: "Name of Secrets Manager Secret that stores the GitHub PAT"
+        docker_path:
+          title: "Docker Path"
+          description: "Docker build context is the set of files located in the specified PATH (Default is .)"
+          type: string
+          default: "."
+          minLength: 1
+          maxLength: 300


### PR DESCRIPTION
This adds support for building repos with Dockerfiles and code in sub-directories.